### PR TITLE
Support configuring dashboards on remote host

### DIFF
--- a/filter_plugins/dashboards.py
+++ b/filter_plugins/dashboards.py
@@ -1,13 +1,13 @@
-# Copyright (c) 2017 StackHPC Ltd.
+# Copyright (c) 2017-2018 StackHPC Ltd.
+import base64
 import json
 
 
-def extract_new_dashboards(dashboard_meta, existing_dashboard_meta):
-    """ Extract new dashboard
+def extract_new_dashboards(dashboards, existing_dashboard_meta):
+    """ Extract new dashboards
 
     Args:
-        dashboard_meta: List of available dashboard files as obtained with
-                        the Ansible find module.
+        dashboards: List of available dashboards (b64 encoded JSON).
         existing_dashboard_meta: List of dashboard metadata returned from
                                  querying api/search for Grafana.
 
@@ -17,19 +17,11 @@ def extract_new_dashboards(dashboard_meta, existing_dashboard_meta):
     """
     existing_dashboard_titles = {d['title'] for d in json.loads(
                                           existing_dashboard_meta['content'])}
-    available_dashboards = _load_dashboards(dashboard_meta)
+    available_dashboards = [json.loads(
+                       base64.b64decode(db['content'])) for db in dashboards]
     new_dashboards = [d for d in available_dashboards if d[
                        'dashboard']['title'] not in existing_dashboard_titles]
     return new_dashboards
-
-
-def _load_dashboards(dashboard_meta):
-    dashboards = []
-    for dashboard in dashboard_meta:
-        with open(dashboard['path']) as json_data:
-            dashboards.append(json.load(json_data))
-    return dashboards
-
 
 class FilterModule(object):
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -103,6 +103,12 @@
     patterns: '*.json'
   register: grafana_conf_available_dashboards
 
+- name: Slurp available dashboards
+  slurp:
+    src: "{{ item['path'] }}"
+  register: grafana_conf_available_dashboard_contents
+  with_items: "{{ grafana_conf_available_dashboards['files'] }}"
+
 - name: Add new dashboards
   uri:
     method: POST
@@ -112,4 +118,5 @@
     body_format: json
     body: "{{ item }}"
     force_basic_auth: true
-  with_items: "{{ grafana_conf_available_dashboards['files']|extract_new_dashboards(grafana_conf_existing_dashboards) }}"
+  changed_when: True
+  with_items: "{{ grafana_conf_available_dashboard_contents['results']|extract_new_dashboards(grafana_conf_existing_dashboards) }}"


### PR DESCRIPTION
Previously, the dashboards were expected to be on the ansible control
host. Since the Grafana API may not always be accessible from there,
the dashboards should be copied to the remote host. This change
supports that.

An alternative to copying the contents of each dashboard back to the
ansible control host could be to compute the hash of each dashboard
on the remote host before comparing it to hashes of the existing
dashboards. However, to prevent overwriting tweaks to dashboards we
choose to compare them by title, and do not look for an exact
match. If an admin wants to re-install a particular dashboard they
can delete it, and then run this role. Since the dashboards are not
large this should improse little overhead.