### PR TITLE
Don't assume a user's primary group name is the same as the username

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -115,8 +115,8 @@
     path: "{{ grafana_conf_grafana_dashboard_repo.checkout_path }}"
     state: directory
     mode: 0755
-    owner: "{{ ansible_user_id }}"
-    group: "{{ ansible_user_id }}"
+    owner: "{{ ansible_user_uid }}"
+    group: "{{ ansible_user_gid }}"
   become: True
   when: grafana_conf_dashboard_repo_set
 


### PR DESCRIPTION
In some environments a user's primary group isn't the same as their
username, so this change introduces the `ansible_user_gid` fact when
specifying permissions.

This change also updates the owner to be `ansible_user_uid` which should
always be present.